### PR TITLE
chore/expo-preview

### DIFF
--- a/EXPO_PREVIEW.md
+++ b/EXPO_PREVIEW.md
@@ -1,0 +1,12 @@
+# Expo UI Preview
+
+This file explains how to run the app in Expo preview mode without native HealthKit or Health Connect integrations.
+
+## Steps
+
+1. Clone the repo and checkout the `chore/expo-preview` branch.
+
+```bash
+git clone https://github.com/to873/health.git
+cd health
+git checkout chore/expo-preview

--- a/docs/stubs/HealthService.expo.ts
+++ b/docs/stubs/HealthService.expo.ts
@@ -1,0 +1,24 @@
+// Minimal HealthService stub for Expo UI preview (no native Health Connect / HealthKit).
+// Copy this into your Expo app as: src/services/health/HealthService.ts
+
+export async function ensurePermissions(): Promise<boolean> {
+  // No runtime permissions in this Expo preview
+  return false;
+}
+
+export async function isHealthAppAvailable(): Promise<boolean> {
+  // Health Connect / Health app not used in Expo
+  return false;
+}
+
+export async function getTodaySteps(): Promise<number> {
+  // No health source in Expo — return 0 so the UI renders
+  return 0;
+}
+
+export type StepSample = { start: string; end: string; steps: number };
+
+export async function getStepSamples(_: { start: Date; end: Date }): Promise<StepSample[]> {
+  // Empty list just renders empty/zero states
+  return [];
+}


### PR DESCRIPTION
Adds an Expo UI preview stub (HealthService.expo.ts) so the app can render UI without native HealthKit/Health Connect.
